### PR TITLE
Reexport shvproto

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod streamrw;
 pub mod util;
 
 pub use rpcmessage::{RpcMessage, RpcMessageMetaTags};
+pub use shvproto::{self, RpcValue};
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
Let users import and use the same version of shvproto as used by this crate.