### PR TITLE
Introduce methods for SHV paths and methods discovery

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs.git", branch = "master", version = "3.0.0" }
+shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs.git", branch = "master", version = "3.0.10" }
 
 futures = "0.3.29"
 log = "0.4.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "shvrpc"
-version = "3.0.3"
+version = "3.0.4"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs.git", branch = "master", version = "3.0.10" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod rpc;
 pub mod rpctype;
 pub mod rpcframe;
 pub mod rpcmessage;
+pub mod rpcdiscovery;
 pub mod serialrw;
 pub mod streamrw;
 pub mod util;

--- a/src/metamethod.rs
+++ b/src/metamethod.rs
@@ -147,7 +147,7 @@ impl MetaMethod {
                 m.insert(DirAttribute::Flags.into(), self.flags.into());
                 m.insert(DirAttribute::Param.into(), (self.param).into());
                 m.insert(DirAttribute::Result.into(), (self.result).into());
-                m.insert(DirAttribute::Access.into(), (self.access as i32).into());
+                m.insert(DirAttribute::AccessLevel.into(), (self.access as i32).into());
                 m.into()
             }
             DirFormat::Map => {
@@ -156,7 +156,7 @@ impl MetaMethod {
                 m.insert(DirAttribute::Flags.into(), self.flags.into());
                 m.insert(DirAttribute::Param.into(), (self.param).into());
                 m.insert(DirAttribute::Result.into(), (self.result).into());
-                m.insert(DirAttribute::Access.into(), (self.access as i32).into());
+                m.insert(DirAttribute::AccessLevel.into(), (self.access as i32).into());
                 m.insert("description".into(), (self.description).into());
                 m.into()
             }
@@ -171,7 +171,7 @@ pub enum DirAttribute {
     Flags,
     Param,
     Result,
-    Access,
+    AccessLevel,
 }
 impl From<DirAttribute> for i32 {
     fn from(val: DirAttribute) -> Self {
@@ -181,11 +181,11 @@ impl From<DirAttribute> for i32 {
 impl From<DirAttribute> for &str {
     fn from(val: DirAttribute) -> Self {
         match val {
-            DirAttribute::Name => {"name"}
-            DirAttribute::Flags => {"flags"}
-            DirAttribute::Param => {"param"}
-            DirAttribute::Result => {"result"}
-            DirAttribute::Access => {"access"}
+            DirAttribute::Name => "name",
+            DirAttribute::Flags => "flags",
+            DirAttribute::Param => "param",
+            DirAttribute::Result => "result",
+            DirAttribute::AccessLevel => "access",
         }
     }
 }

--- a/src/metamethod.rs
+++ b/src/metamethod.rs
@@ -101,10 +101,13 @@ impl TryFrom<i32> for AccessLevel {
 impl TryFrom<&RpcValue> for AccessLevel {
     type Error = String;
     fn try_from(value: &RpcValue) -> Result<Self, Self::Error> {
-        if let shvproto::rpcvalue::Value::Int(val) = value.value() {
-            (*val as i32).try_into()
-        } else {
-            Err(format!("Wrong RpcValue type for AccessLevel: {}", value.type_name()))
+        use shvproto::rpcvalue::Value;
+        match value.value() {
+            Value::Int(val) => (*val as i32).try_into(),
+            Value::String(val) =>
+                AccessLevel::from_str(val.as_str())
+                .ok_or_else(|| format!("Wrong value of AccessLevel: {}", val)),
+            _ => Err(format!("Wrong RpcValue type for AccessLevel: {}", value.type_name())),
         }
     }
 }

--- a/src/metamethod.rs
+++ b/src/metamethod.rs
@@ -185,6 +185,7 @@ impl From<DirAttribute> for &str {
             DirAttribute::Flags => "flags",
             DirAttribute::Param => "param",
             DirAttribute::Result => "result",
+            // TODO: some implementations return "accessGrant" key in the result of dir
             DirAttribute::AccessLevel => "access",
         }
     }

--- a/src/metamethod.rs
+++ b/src/metamethod.rs
@@ -80,7 +80,7 @@ impl From<&str> for AccessLevel {
 }
 
 impl TryFrom<i32> for AccessLevel {
-    type Error = ();
+    type Error = String;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
         match value {
@@ -93,7 +93,18 @@ impl TryFrom<i32> for AccessLevel {
             value if value == AccessLevel::SuperService as i32 => Ok(AccessLevel::SuperService),
             value if value == AccessLevel::Developer as i32 => Ok(AccessLevel::Developer),
             value if value == AccessLevel::Superuser as i32 => Ok(AccessLevel::Superuser),
-            _ => Err(()),
+            _ => Err(format!("Invalid access level: {value}")),
+        }
+    }
+}
+
+impl TryFrom<&RpcValue> for AccessLevel {
+    type Error = String;
+    fn try_from(value: &RpcValue) -> Result<Self, Self::Error> {
+        if let shvproto::rpcvalue::Value::Int(val) = value.value() {
+            (*val as i32).try_into()
+        } else {
+            Err(format!("Wrong RpcValue type for AccessLevel: {}", value.type_name()))
         }
     }
 }

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -76,13 +76,13 @@ impl TryFrom<&RpcValue> for LsResult {
 pub enum DirParam {
     Brief,
     Full,
-    BriefMethod(String),
+    Exists(String),
 }
 
 impl From<&RpcValue> for DirParam {
     fn from(rpcvalue: &RpcValue) -> Self {
         match rpcvalue.value() {
-            shvproto::Value::String(param) => DirParam::BriefMethod(param.to_string()),
+            shvproto::Value::String(param) => DirParam::Exists(param.to_string()),
             shvproto::Value::Bool(true) => DirParam::Full,
             _ => DirParam::Brief,
         }
@@ -101,7 +101,7 @@ impl From<DirParam> for RpcValue {
         match value {
             DirParam::Brief => false.into(),
             DirParam::Full => true.into(),
-            DirParam::BriefMethod(method) => method.into(),
+            DirParam::Exists(method) => method.into(),
         }
     }
 }
@@ -213,14 +213,14 @@ mod test {
     fn dir_param_from_rpcvalue() {
         assert_eq!(DirParam::Brief, (&RpcValue::from(())).into());
         assert_eq!(DirParam::Brief, (&RpcValue::from(false)).into());
-        assert_eq!(DirParam::BriefMethod("foo".into()), (&RpcValue::from("foo")).into());
+        assert_eq!(DirParam::Exists("foo".into()), (&RpcValue::from("foo")).into());
         assert_eq!(DirParam::Full, (&RpcValue::from(true)).into());
     }
 
     #[test]
     fn dir_param_into_rpcvalue() {
         assert_eq!(RpcValue::from(DirParam::Brief), false.into());
-        assert_eq!(RpcValue::from(DirParam::BriefMethod("foo".into())), "foo".into());
+        assert_eq!(RpcValue::from(DirParam::Exists("foo".into())), "foo".into());
         assert_eq!(RpcValue::from(DirParam::Full), true.into());
     }
 

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -44,7 +44,7 @@ impl From<DirParam> for RpcValue {
 pub struct MethodInfo {
     pub name: String,
     pub flags: u32,
-    pub access: AccessLevel,
+    pub access_level: AccessLevel,
     pub param: String,
     pub result: String,
 }
@@ -68,7 +68,7 @@ impl TryFrom<&RpcValue> for MethodInfo {
                     flags: get_key(DirAttribute::Flags)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Flags, &e))?,
-                    access: get_key(DirAttribute::Access)?
+                    access_level: get_key(DirAttribute::Access)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Access, &e))?,
                     param: get_key(DirAttribute::Param)?
@@ -97,7 +97,7 @@ impl TryFrom<&RpcValue> for MethodInfo {
                     flags: get_key(DirAttribute::Flags)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Flags, &e))?,
-                    access: get_key(DirAttribute::Access)?
+                    access_level: get_key(DirAttribute::Access)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Access, &e))?,
                     param: get_key(DirAttribute::Param)?
@@ -160,7 +160,7 @@ mod test {
         MethodInfo {
             name: "method".to_string(),
             flags: Flag::IsGetter.into(),
-            access: AccessLevel::Read,
+            access_level: AccessLevel::Read,
             param: "param".to_string(),
             result: "result".to_string(),
         }

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -187,6 +187,28 @@ pub enum DirResult {
     List(Vec<MethodInfo>),
 }
 
+impl TryFrom<DirResult> for bool {
+    type Error = String;
+    fn try_from(value: DirResult) -> Result<Self, Self::Error> {
+        if let DirResult::Exists(val) = value {
+            Ok(val)
+        } else {
+            Err(format!("Cannot convert `dir` result to bool. Actual result: {:?}", value))
+        }
+    }
+}
+
+impl TryFrom<DirResult> for Vec<MethodInfo> {
+    type Error = String;
+    fn try_from(value: DirResult) -> Result<Self, Self::Error> {
+        if let DirResult::List(val) = value {
+            Ok(val)
+        } else {
+            Err(format!("Cannot convert `dir` result to Vec<MethodInfo>. Actual result: {:?}", value))
+        }
+    }
+}
+
 impl TryFrom<&RpcValue> for DirResult {
     type Error = String;
     fn try_from(rpcvalue: &RpcValue) -> Result<Self, Self::Error> {

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -161,19 +161,19 @@ impl TryFrom<&RpcValue> for MethodInfo {
 
 #[derive(Debug)]
 pub enum DirResult {
-    MethodExists(bool),
-    Methods(Vec<MethodInfo>),
+    Exists(bool),
+    List(Vec<MethodInfo>),
 }
 
 impl TryFrom<&RpcValue> for DirResult {
     type Error = String;
     fn try_from(rpcvalue: &RpcValue) -> Result<Self, Self::Error> {
         match rpcvalue.value() {
-            shvproto::Value::Bool(false) | shvproto::Value::Null => Ok(DirResult::MethodExists(false)),
-            shvproto::Value::Bool(true) => Ok(DirResult::MethodExists(true)),
+            shvproto::Value::Bool(false) | shvproto::Value::Null => Ok(DirResult::Exists(false)),
+            shvproto::Value::Bool(true) => Ok(DirResult::Exists(true)),
             shvproto::Value::Map(_) | shvproto::Value::IMap(_) =>
-                MethodInfo::try_from(rpcvalue).map(|_| DirResult::MethodExists(true)),
-            shvproto::Value::List(_) => Ok(DirResult::Methods(rpcvalue.try_into()?)),
+                MethodInfo::try_from(rpcvalue).map(|_| DirResult::Exists(true)),
+            shvproto::Value::List(_) => Ok(DirResult::List(rpcvalue.try_into()?)),
             _ => Err(format!("Wrong RpcValue type: {}", rpcvalue.type_name()))
         }
     }

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -68,9 +68,9 @@ impl TryFrom<&RpcValue> for MethodInfo {
                     flags: get_key(DirAttribute::Flags)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Flags, &e))?,
-                    access_level: get_key(DirAttribute::Access)?
+                    access_level: get_key(DirAttribute::AccessLevel)?
                         .try_into()
-                        .map_err(|e| format_err(DirAttribute::Access, &e))?,
+                        .map_err(|e| format_err(DirAttribute::AccessLevel, &e))?,
                     param: get_key(DirAttribute::Param)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Param, &e))?,
@@ -97,9 +97,9 @@ impl TryFrom<&RpcValue> for MethodInfo {
                     flags: get_key(DirAttribute::Flags)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Flags, &e))?,
-                    access_level: get_key(DirAttribute::Access)?
+                    access_level: get_key(DirAttribute::AccessLevel)?
                         .try_into()
-                        .map_err(|e| format_err(DirAttribute::Access, &e))?,
+                        .map_err(|e| format_err(DirAttribute::AccessLevel, &e))?,
                     param: get_key(DirAttribute::Param)?
                         .try_into()
                         .map_err(|e| format_err(DirAttribute::Param, &e))?,
@@ -180,7 +180,7 @@ mod test {
         let rv_imap: RpcValue = [
             (i32::from(DirAttribute::Name), RpcValue::from("method")),
             (i32::from(DirAttribute::Flags), RpcValue::from(Flag::IsGetter as u32)),
-            (i32::from(DirAttribute::Access), RpcValue::from(AccessLevel::Read as i32)),
+            (i32::from(DirAttribute::AccessLevel), RpcValue::from(AccessLevel::Read as i32)),
             (i32::from(DirAttribute::Param), RpcValue::from("param")),
             (i32::from(DirAttribute::Result), RpcValue::from("result")),
         ].into_iter().collect::<BTreeMap::<_,_>>().into();

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -1,0 +1,215 @@
+use shvproto::RpcValue;
+
+use crate::metamethod::{AccessLevel, DirAttribute};
+
+#[derive(Debug, PartialEq)]
+pub enum DirParam {
+    Brief,
+    Full,
+    BriefMethod(String),
+}
+
+impl From<&RpcValue> for DirParam {
+    fn from(rpcvalue: &RpcValue) -> Self {
+        match rpcvalue.value() {
+            shvproto::Value::String(param) => DirParam::BriefMethod(param.to_string()),
+            shvproto::Value::Bool(true) => DirParam::Full,
+            _ => DirParam::Brief,
+        }
+
+    }
+}
+
+impl From<Option<&RpcValue>> for DirParam {
+    fn from(value: Option<&RpcValue>) -> Self {
+        match value {
+            Some(rpcval) => rpcval.into(),
+            None => DirParam::Brief,
+        }
+    }
+}
+
+impl From<DirParam> for RpcValue {
+    fn from(value: DirParam) -> Self {
+        match value {
+            DirParam::Brief => false.into(),
+            DirParam::Full => true.into(),
+            DirParam::BriefMethod(method) => method.into(),
+        }
+    }
+}
+
+
+#[derive(Debug,PartialEq)]
+pub struct MethodInfo {
+    pub name: String,
+    pub flags: u32,
+    pub access: AccessLevel,
+    pub param: String,
+    pub result: String,
+}
+
+impl TryFrom<&RpcValue> for MethodInfo {
+    type Error = String;
+    fn try_from(value: &RpcValue) -> Result<Self, Self::Error> {
+        match value.value() {
+            shvproto::Value::Map(map) => {
+                let get_key = |key: DirAttribute| {
+                    map.get(key.into()).ok_or_else(|| format!("Missing MethodInfo key `{}` in Map", <&str>::from(key)))
+                };
+                let format_err = |field: DirAttribute, err: &String| {
+                    let field_name: &str = field.into();
+                    format!("Invalid MethodInfo field `{field_name}` in Map: {err}")
+                };
+                Ok(MethodInfo {
+                    name: get_key(DirAttribute::Name)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Name, &e))?,
+                    flags: get_key(DirAttribute::Flags)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Flags, &e))?,
+                    access: get_key(DirAttribute::Access)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Access, &e))?,
+                    param: get_key(DirAttribute::Param)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Param, &e))?,
+                    result: get_key(DirAttribute::Result)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Result, &e))?,
+                })
+            }
+            shvproto::Value::IMap(imap) => {
+                let get_key = |key: DirAttribute| {
+                    imap.get(&i32::from(key)).ok_or_else(||
+                        format!("Missing MethodInfo key `{}`({}) in IMap", i32::from(key), <&str>::from(key)).to_string()
+                    )
+                };
+                let format_err = |field: DirAttribute, err: &String| {
+                    let field_name: &str = field.into();
+                    let field_num: i32 = field.into();
+                    format!("Invalid MethodInfo field `{field_name}`({field_num}) in IMap: {err}")
+                };
+                Ok(MethodInfo {
+                    name: get_key(DirAttribute::Name)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Name, &e))?,
+                    flags: get_key(DirAttribute::Flags)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Flags, &e))?,
+                    access: get_key(DirAttribute::Access)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Access, &e))?,
+                    param: get_key(DirAttribute::Param)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Param, &e))?,
+                    result: get_key(DirAttribute::Result)?
+                        .try_into()
+                        .map_err(|e| format_err(DirAttribute::Result, &e))?,
+                })
+            }
+            _ => Err(format!("Wrong RpcValue type for MethodInfo: {}", value.type_name())),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum DirResult {
+    MethodExists(bool),
+    Methods(Vec<MethodInfo>),
+}
+
+impl TryFrom<&RpcValue> for DirResult {
+    type Error = String;
+    fn try_from(rpcvalue: &RpcValue) -> Result<Self, Self::Error> {
+        match rpcvalue.value() {
+            shvproto::Value::Bool(false) | shvproto::Value::Null => Ok(DirResult::MethodExists(false)),
+            shvproto::Value::Bool(true) => Ok(DirResult::MethodExists(true)),
+            shvproto::Value::Map(_) | shvproto::Value::IMap(_) =>
+                MethodInfo::try_from(rpcvalue).map(|_| DirResult::MethodExists(true)),
+            shvproto::Value::List(_) => Ok(DirResult::Methods(rpcvalue.try_into()?)),
+            _ => Err(format!("Wrong RpcValue type: {}", rpcvalue.type_name()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use crate::metamethod::Flag;
+
+    use super::*;
+
+    #[test]
+    fn dir_param_from_rpcvalue() {
+        assert_eq!(DirParam::Brief, (&RpcValue::from(())).into());
+        assert_eq!(DirParam::Brief, (&RpcValue::from(false)).into());
+        assert_eq!(DirParam::BriefMethod("foo".into()), (&RpcValue::from("foo")).into());
+        assert_eq!(DirParam::Full, (&RpcValue::from(true)).into());
+    }
+
+    #[test]
+    fn dir_param_into_rpcvalue() {
+        assert_eq!(RpcValue::from(DirParam::Brief), false.into());
+        assert_eq!(RpcValue::from(DirParam::BriefMethod("foo".into())), "foo".into());
+        assert_eq!(RpcValue::from(DirParam::Full), true.into());
+    }
+
+    fn method_info() -> MethodInfo {
+        MethodInfo {
+            name: "method".to_string(),
+            flags: Flag::IsGetter.into(),
+            access: AccessLevel::Read,
+            param: "param".to_string(),
+            result: "result".to_string(),
+        }
+    }
+
+    #[test]
+    fn method_info_from_rpcvalue() {
+        let rv_map: RpcValue = shvproto::make_map!(
+            "name" => "method",
+            "flags" => Flag::IsGetter as u32,
+            "access" => AccessLevel::Read as i32,
+            "param" => "param",
+            "result" => "result",
+        ).into();
+        assert_eq!(method_info(), (&rv_map).try_into().unwrap());
+
+        let rv_imap: RpcValue = [
+            (i32::from(DirAttribute::Name), RpcValue::from("method")),
+            (i32::from(DirAttribute::Flags), RpcValue::from(Flag::IsGetter as u32)),
+            (i32::from(DirAttribute::Access), RpcValue::from(AccessLevel::Read as i32)),
+            (i32::from(DirAttribute::Param), RpcValue::from("param")),
+            (i32::from(DirAttribute::Result), RpcValue::from("result")),
+        ].into_iter().collect::<BTreeMap::<_,_>>().into();
+        assert_eq!(method_info(), (&rv_imap).try_into().unwrap());
+    }
+
+    #[test]
+    #[should_panic]
+    fn method_info_from_rpcvalue_missing_field() {
+        let rv_map: RpcValue = shvproto::make_map!(
+            "name" => "method",
+            "flags" => Flag::IsGetter as u32,
+            "access" => AccessLevel::Read as i32,
+            // "param" => "param",
+            "result" => "result",
+        ).into();
+        let _:MethodInfo = (&rv_map).try_into().unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn method_info_from_rpcvalue_wrong_field_type() {
+        let rv_map: RpcValue = shvproto::make_map!(
+            "name" => "method",
+            "flags" => Flag::IsGetter as u32,
+            "access" => AccessLevel::Read as i32,
+            "param" => (),
+            "result" => "result",
+        ).into();
+        let _:MethodInfo = (&rv_map).try_into().unwrap();
+    }
+}

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -38,6 +38,28 @@ pub enum LsResult {
     List(Vec<String>),
 }
 
+impl TryFrom<LsResult> for bool {
+    type Error = String;
+    fn try_from(value: LsResult) -> Result<Self, Self::Error> {
+        if let LsResult::Exists(val) = value {
+            Ok(val)
+        } else {
+            Err(format!("Cannot convert `ls` result to bool. Actual result: {:?}", value))
+        }
+    }
+}
+
+impl TryFrom<LsResult> for Vec<String> {
+    type Error = String;
+    fn try_from(value: LsResult) -> Result<Self, Self::Error> {
+        if let LsResult::List(val) = value {
+            Ok(val)
+        } else {
+            Err(format!("Cannot convert `ls` result to Vec<String>. Actual result: {:?}", value))
+        }
+    }
+}
+
 impl TryFrom<&RpcValue> for LsResult {
     type Error = String;
     fn try_from(rpcvalue: &RpcValue) -> Result<Self, Self::Error> {


### PR DESCRIPTION
In this PR `DirParam`, `MethodInfo` and `DirResult` types are implemented.