### PR TITLE
Implement `TryFrom<RpcValue>` for `LsResult` and `DirResult`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.0.4"
+version = "3.0.5"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Impls of TryFrom that take RpcValue by value are useful for generic functions where the bounds are defined as:

   T: TryFrom<RpcValue, Error = E>,
   E: std::fmt::Display,

Because of blanket impl TryFrom<T> for T with Error = Infallible and Infallible having impl std::fmt::Display, it is possible to have just a single generic implementation of a function working with RpcValue and also any type that TryFrom<RpcValue> is implemented for.