### PR TITLE
rpcmessage: Derive `Clone` for `RpcError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.0.6"
+version = "3.0.7"
 edition = "2021"
 
 [dependencies]

--- a/src/rpcmessage.rs
+++ b/src/rpcmessage.rs
@@ -375,6 +375,7 @@ impl TryFrom<i32> for RpcErrorCode {
     }
 }
 
+#[derive(Clone)]
 pub struct RpcError {
     pub code: RpcErrorCode,
     pub message: String,


### PR DESCRIPTION
Needed for RpcError propagation to a client code
where an owned Result is returned.