### PR TITLE
Rpc call timeout 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crc = "3.0.1"
 serde = "1.0.193"
 serde_yaml = "0.9.29"
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
+futures-time = "3.0.0"
 
 [dev-dependencies]
 env_logger = "0.11.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ serde = "1.0.193"
 serde_yaml = "0.9.29"
 async-std = { version = "1.12.0", features = ["attributes"], optional = true }
 
+[dev-dependencies]
+env_logger = "0.11.5"
+
 [features]
 async-std = ["dep:async-std"]
 

--- a/src/framerw.rs
+++ b/src/framerw.rs
@@ -2,7 +2,7 @@ use std::io::BufReader;
 use std::mem::take;
 use async_trait::async_trait;
 use futures::{AsyncRead, AsyncReadExt};
-use log::{debug, log, Level};
+use log::{log, Level};
 use crate::rpcframe::{Protocol, RpcFrame};
 use shvproto::{ChainPackReader, ChainPackWriter, MetaMap, Reader, RpcValue, Writer};
 use crate::{RpcMessage, RpcMessageMetaTags};
@@ -22,6 +22,20 @@ impl RpcFrameReception {
         }
     }
 }
+// impl RpcMessageMetaTags for RpcFrameReception {
+//     type Target = Self;
+//
+//     fn tag(&self, id: i32) -> Option<&RpcValue> {
+//         if id == Tag::RequestId as i32 { return self.request_id().map(|v| v.into()) }
+//         if id == Tag::ShvPath as i32 { return self.shv_path().map(|v| v.into()) }
+//         if id == Tag::Method as i32 { return self.method().map(|v| v.into()) }
+//         if id == Tag::Source as i32 { return self.source().map(|v| v.into()) }
+//         panic!("Unsupported tag.");
+//     }
+//     fn set_tag(&mut self, id: i32, val: Option<RpcValue>) -> &mut Self::Target {
+//         panic!("RpcFrameReception is RO.")
+//     }
+// }
 #[derive(Debug)]
 pub enum ReceiveFrameError {
     Timeout,
@@ -117,8 +131,7 @@ pub trait FrameReader {
 
     async fn receive_frame(&mut self) -> crate::Result<RpcFrame> {
         loop {
-            let f = self.receive_frame_or_request_id().await?;
-            if let RpcFrameReception::Frame(frame) = f {
+            if let RpcFrameReception::Frame(frame) = self.receive_frame_or_request_id().await? {
                 return Ok(frame);
             }
         }

--- a/src/framerw.rs
+++ b/src/framerw.rs
@@ -89,8 +89,9 @@ pub(crate) trait FrameReaderPrivate {
                     self.frame_data_ref_mut().meta = Some(meta);
                     return Ok(rmeta);
                 } else {
-                    log!(target: "FrameReader", Level::Warn, "Meta data read error");
-                    return Err(ReceiveFrameError::FrameError);
+                    // log!(target: "FrameReader", Level::Warn, "Meta data read error");
+                    //log!(target: "FrameReader", Level::Warn, "bytes:\n{}\n-------------", crate::util::hex_dump(&self.frame_data_ref_mut().data[..]));
+                    continue;
                 }
             }
             if self.frame_data_ref_mut().complete {

--- a/src/framerw.rs
+++ b/src/framerw.rs
@@ -68,7 +68,7 @@ pub(crate) trait FrameReaderPrivate {
     fn frame_data_ref_mut(&mut self) -> &mut FrameData;
     fn frame_data_ref(&self) -> &FrameData;
     fn reset_frame_data(&mut self);
-    async fn receive_frame_or_request_id_inner(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
+    async fn receive_frame_or_meta_inner(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
         loop {
             if !self.frame_data_ref().complete {
                 self.get_byte().await?;
@@ -108,8 +108,8 @@ pub(crate) trait FrameReaderPrivate {
             }
         }
     }
-    async fn receive_frame_or_request_id_private(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
-        let ret = self.receive_frame_or_request_id_inner().await;
+    async fn receive_frame_or_meta_private(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
+        let ret = self.receive_frame_or_meta_inner().await;
         if ret.is_err() {
             self.reset_frame_data();
         }
@@ -118,11 +118,11 @@ pub(crate) trait FrameReaderPrivate {
 }
 #[async_trait]
 pub trait FrameReader {
-    async fn receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError>;
+    async fn receive_frame_or_meta(&mut self) -> Result<RpcFrameReception, ReceiveFrameError>;
 
     async fn receive_frame(&mut self) -> crate::Result<RpcFrame> {
         loop {
-            if let RpcFrameReception::Frame(frame) = self.receive_frame_or_request_id().await? {
+            if let RpcFrameReception::Frame(frame) = self.receive_frame_or_meta().await? {
                 return Ok(frame);
             }
         }

--- a/src/framerw.rs
+++ b/src/framerw.rs
@@ -41,22 +41,17 @@ impl RawData {
         self.consumed = 0;
     }
 }
-pub struct FrameData {
+pub(crate) struct FrameData {
     pub(crate) complete: bool,
     pub(crate) meta: Option<MetaMap>,
     pub(crate) data: Vec<u8>,
 }
 #[async_trait]
-pub trait FrameReader {
+pub(crate) trait FrameReaderPrivate {
     async fn get_byte(&mut self) -> Result<(), ReceiveFrameError>;
     fn can_read_meta(&self) -> bool;
     fn frame_data_ref_mut(&mut self) -> &mut FrameData;
     fn reset_frame_data(&mut self);
-    async fn receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
-        let ret = self.__receive_frame_or_request_id().await;
-        self.reset_frame_data();
-        ret
-    }
     async fn __receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
         loop {
             self.get_byte().await?;
@@ -100,6 +95,10 @@ pub trait FrameReader {
             }
         }
     }
+}
+#[async_trait]
+pub trait FrameReader {
+    async fn receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError>;
 
     async fn receive_frame(&mut self) -> crate::Result<RpcFrame> {
         loop {

--- a/src/framerw.rs
+++ b/src/framerw.rs
@@ -235,6 +235,10 @@ pub(crate) mod test {
     pub(crate) fn from_hex(hex: &str) -> Vec<u8> {
         let mut ret = vec![];
         for s in hex.split(' ') {
+            let s = s.trim();
+            if s.is_empty() {
+                continue;
+            }
             let n = match s {
                 "STX" => { 0xa2 }
                 "ESTX" => { 0x02 }

--- a/src/rpcmessage.rs
+++ b/src/rpcmessage.rs
@@ -20,7 +20,6 @@ pub type PeerId = i64;
 // backward compatibility
 pub type CliId = PeerId;
 
-#[allow(dead_code)]
 pub enum Tag {
     RequestId = rpctype::Tag::USER as isize, // 8
     ShvPath = 9,
@@ -35,8 +34,6 @@ pub enum Tag {
     Repeat = 20,
     MAX
 }
-
-#[allow(dead_code)]
 pub enum Key {Params = 1, Result, Error, ErrorCode, ErrorMessage, MAX }
 
 #[derive(Clone, Debug)]
@@ -190,14 +187,7 @@ impl Default for RpcMessage {
         RpcMessage(RpcValue::new(IMap::new().into(),Some(mm)))
     }
 }
-/*
 
-impl DerefMut for RpcMessage {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-*/
 pub trait RpcMessageMetaTags {
     type Target;
 
@@ -226,9 +216,6 @@ pub trait RpcMessageMetaTags {
     fn shv_path(&self) -> Option<&str> {
         self.tag(Tag::ShvPath as i32).map(RpcValue::as_str)
     }
-    //fn shv_path_or_empty(&self) -> &str {
-    //    self.shv_path().unwrap_or("")
-    //}
     fn set_shvpath(&mut self, shv_path: &str) -> &mut Self::Target {
         self.set_tag(Tag::ShvPath as i32, Some(RpcValue::from(shv_path)))
     }
@@ -303,7 +290,7 @@ pub trait RpcMessageMetaTags {
     }
 }
 impl RpcMessageMetaTags for RpcMessage {
-    type Target = RpcMessage;
+    type Target = Self;
 
     fn tag(&self, id: i32) -> Option<&RpcValue> {
         self.tag(id)

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -78,7 +78,8 @@ impl<R: AsyncRead + Unpin + Send> SerialFrameReader<R> {
     }
     async fn get_raw_byte(&mut self) -> Result<u8, ReceiveFrameError> {
         if self.raw_data.raw_bytes_available() == 0 {
-            read_bytes(&mut self.reader, &mut self.raw_data.data).await?;
+            let with_timeout = !self.raw_data.data.is_empty();
+            read_bytes(&mut self.reader, &mut self.raw_data.data, with_timeout).await?;
         }
         let b = self.raw_data.data[self.raw_data.consumed];
         self.raw_data.consumed += 1;

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -16,12 +16,6 @@ const ESTX: u8 = 0x02;
 const EETX: u8 = 0x03;
 const EATX: u8 = 0x04;
 const EESC: u8 = 0x0A;
-pub enum EscapedByte {
-    Data(u8),
-    Stx,
-    Etx,
-    // Atx,
-}
 fn is_byte_available(raw_data: &RawData) -> bool {
     if raw_data.raw_bytes_available() == 0 {
         false

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -196,6 +196,9 @@ impl<R: AsyncRead + Unpin + Send> FrameReaderPrivate for SerialFrameReader<R> {
     fn frame_data_ref_mut(&mut self) -> &mut FrameData {
         &mut self.frame_data
     }
+
+    fn frame_data_ref(&self) -> &FrameData { &self.frame_data }
+
     fn reset_frame_data(&mut self) {
         self.reset_frame(false)
     }

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -209,8 +209,7 @@ impl<R: AsyncRead + Unpin + Send> FrameReaderPrivate for SerialFrameReader<R> {
 #[async_trait]
 impl<R: AsyncRead + Unpin + Send> FrameReader for SerialFrameReader<R> {
     async fn receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
-        let ret = self.receive_frame_or_request_id_private().await;
-        ret
+        self.receive_frame_or_request_id_private().await
     }
 }
 pub struct SerialFrameWriter<W: AsyncWrite + Unpin + Send> {

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -204,8 +204,8 @@ impl<R: AsyncRead + Unpin + Send> FrameReaderPrivate for SerialFrameReader<R> {
 }
 #[async_trait]
 impl<R: AsyncRead + Unpin + Send> FrameReader for SerialFrameReader<R> {
-    async fn receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
-        self.receive_frame_or_request_id_private().await
+    async fn receive_frame_or_meta(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
+        self.receive_frame_or_meta_private().await
     }
 }
 pub struct SerialFrameWriter<W: AsyncWrite + Unpin + Send> {
@@ -365,14 +365,14 @@ mod test {
                 debug!("bytes:\n{}\n-------------", hex_dump(&buff2));
                 let buffrd = async_std::io::BufReader::new(&*buff2);
                 let mut rd = SerialFrameReader::new(buffrd).with_crc_check(with_crc);
-                let Err(ReceiveFrameError::FrameError(_)) = rd.receive_frame_or_request_id().await else {
+                let Err(ReceiveFrameError::FrameError(_)) = rd.receive_frame_or_meta().await else {
                     panic!("Frame error should be received");
                 };
-                let Ok(RpcFrameReception::Meta{ request_id, .. }) = rd.receive_frame_or_request_id().await else {
+                let Ok(RpcFrameReception::Meta{ request_id, .. }) = rd.receive_frame_or_meta().await else {
                     panic!("Meta should be received");
                 };
                 assert_eq!(request_id, rqid);
-                let Ok(RpcFrameReception::Frame(rd_frame)) = rd.receive_frame_or_request_id().await else {
+                let Ok(RpcFrameReception::Frame(rd_frame)) = rd.receive_frame_or_meta().await else {
                     panic!("Frame should be received");
                 };
                 assert_eq!(&rd_frame, &frame);

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -201,7 +201,6 @@ impl<R: AsyncRead + Unpin + Send> FrameReaderPrivate for SerialFrameReader<R> {
     fn frame_data_ref_mut(&mut self) -> &mut FrameData {
         &mut self.frame_data
     }
-
     fn reset_frame_data(&mut self) {
         self.reset_frame(false)
     }

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -275,7 +275,6 @@ impl<W: AsyncWrite + Unpin + Send> FrameWriter for SerialFrameWriter<W> {
                 [b0, b1, b2, b3]
             }
             let crc = digest.expect("digest should be some here").finalize();
-            //println!("CRC1 {crc}");
             let crc_bytes = u32_to_bytes(crc);
             self.write_escaped(&mut None, &crc_bytes).await?;
         }

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -37,7 +37,8 @@ impl<R: AsyncRead + Unpin + Send> StreamFrameReader<R> {
     }
     async fn get_raw_byte(&mut self) -> Result<u8, ReceiveFrameError> {
         if self.raw_data.raw_bytes_available() == 0 {
-            read_bytes(&mut self.reader, &mut self.raw_data.data).await?;
+            let with_timeout = !self.raw_data.data.is_empty();
+            read_bytes(&mut self.reader, &mut self.raw_data.data, with_timeout).await?;
         }
         let b = self.raw_data.data[self.raw_data.consumed];
         self.raw_data.consumed += 1;

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -98,8 +98,8 @@ impl<R: AsyncRead + Unpin + Send> FrameReaderPrivate for StreamFrameReader<R> {
 }
 #[async_trait]
 impl<R: AsyncRead + Unpin + Send> FrameReader for StreamFrameReader<R> {
-    async fn receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
-        self.receive_frame_or_request_id_private().await
+    async fn receive_frame_or_meta(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
+        self.receive_frame_or_meta_private().await
     }
 }
 // fn read_frame(buff: &[u8]) -> crate::Result<RpcFrame> {
@@ -213,11 +213,11 @@ mod test {
         {
             let buffrd = async_std::io::BufReader::new(&*buff);
             let mut rd = StreamFrameReader::new(buffrd);
-            let Ok(RpcFrameReception::Meta{ request_id, .. }) = rd.receive_frame_or_request_id().await else {
+            let Ok(RpcFrameReception::Meta{ request_id, .. }) = rd.receive_frame_or_meta().await else {
                 panic!("Meta should be received");
             };
             assert_eq!(request_id, rqid);
-            let Ok(RpcFrameReception::Frame(rd_frame)) = rd.receive_frame_or_request_id().await else {
+            let Ok(RpcFrameReception::Frame(rd_frame)) = rd.receive_frame_or_meta().await else {
                 panic!("Frame should be received");
             };
             assert_eq!(&rd_frame, &frame);

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -58,7 +58,7 @@ impl<R: AsyncRead + Unpin + Send> StreamFrameReader<R> {
                         let ReadError{reason, .. } = err;
                         match reason {
                             ReadErrorReason::UnexpectedEndOfStream => { continue }
-                            ReadErrorReason::InvalidCharacter => { return Err(ReceiveFrameError::FrameError) }
+                            ReadErrorReason::InvalidCharacter => { return Err(ReceiveFrameError::FrameError("Cannot read frame length, invalid byte received".into())) }
                         }
                     }
                 };

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -254,6 +254,21 @@ use crate::framerw::test::from_hex;
             assert!(frame.is_ok());
         };
     }
+    #[async_std::test]
+    async fn test_read_multiframe_chunk() {
+        init_log();
+        let data = from_hex(
+            "21 01 8b 41 41 48 45 49 86 07 66 6f 6f 2f 62 61 72 4a 86 03 62 61 7a ff 8a 41 86 05 68 65 6c 6c 6f ff
+                    21 01 8b 41 41 48 45 49 86 07 66 6f 6f 2f 62 61 72 4a 86 03 62 61 7a ff 8a 41 86 05 68 65 6c 6c 6f ff
+                    21 01 8b 41 41 48 45 49 86 07 66 6f 6f 2f 62 61 72 4a 86 03 62 61 7a ff 8a 41 86 05 68 65 6c 6c 6f ff"
+        );
+        let buffrd = async_std::io::BufReader::new(&*data);
+        let mut rd = StreamFrameReader::new(buffrd);
+        for _ in 0 .. 2 {
+            let frame = rd.receive_frame().await;
+            assert!(frame.is_ok());
+        }
+    }
 }
 
 

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -90,6 +90,7 @@ impl<R: AsyncRead + Unpin + Send> FrameReaderPrivate for StreamFrameReader<R> {
     fn frame_data_ref_mut(&mut self) -> &mut FrameData {
         &mut self.frame_data
     }
+    fn frame_data_ref(&self) -> &FrameData { &self.frame_data }
 
     fn reset_frame_data(&mut self) {
         self.reset_frame()

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -92,8 +92,7 @@ impl<R: AsyncRead + Unpin + Send> FrameReaderPrivate for StreamFrameReader<R> {
 #[async_trait]
 impl<R: AsyncRead + Unpin + Send> FrameReader for StreamFrameReader<R> {
     async fn receive_frame_or_request_id(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
-        let ret = self.receive_frame_or_request_id_private().await;
-        ret
+        self.receive_frame_or_request_id_private().await
     }
 }
 // fn read_frame(buff: &[u8]) -> crate::Result<RpcFrame> {

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -1,39 +1,41 @@
 use std::io::{BufReader};
-use std::mem::take;
 use async_trait::async_trait;
 use crate::rpcframe::{Protocol, RpcFrame};
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use futures::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use log::*;
-use shvproto::{ChainPackReader, ChainPackWriter, Reader, ReadError, MetaMap};
-use crate::framerw::{FrameReader, FrameWriter, serialize_meta, RpcFrameReception, ReceiveFrameError, read_bytes, RawData};
+use shvproto::{ChainPackReader, ChainPackWriter, Reader, ReadError};
+use crate::framerw::{FrameReader, FrameWriter, serialize_meta, ReceiveFrameError, read_bytes, RawData, FrameData};
 use shvproto::reader::ReadErrorReason;
-use crate::RpcMessageMetaTags;
 
 pub struct StreamFrameReader<R: AsyncRead + Unpin + Send> {
     reader: R,
-
     frame_len: usize,
-    meta: Option<MetaMap>,
-    data: Vec<u8>,
-
+    frame_data: FrameData,
     raw_data: RawData,
 }
 impl<R: AsyncRead + Unpin + Send> StreamFrameReader<R> {
     pub fn new(reader: R) -> Self {
         Self {
             reader,
-            frame_len: None,
-            meta: None,
-            data: vec![],
+            frame_len: 0,
+            frame_data: FrameData {
+                complete: false,
+                meta: None,
+                data: vec![],
+            },
             raw_data: RawData { data: vec![], consumed: 0 },
         }
     }
-    fn reset_frame(&mut self, frame_len: usiz>) {
-        self.data = vec![];
-        self.meta = None;
-        self.frame_len = frame_len;
+    fn reset_frame(&mut self) {
+        self.frame_data = FrameData {
+            complete: false,
+            meta: None,
+            data: vec![],
+        };
+        self.frame_len = 0;
+        self.raw_data.trim();
     }
-    async fn get_byte(&mut self) -> crate::Result<u8> {
+    async fn get_raw_byte(&mut self) -> Result<u8, ReceiveFrameError> {
         if self.raw_data.raw_bytes_available() == 0 {
             read_bytes(&mut self.reader, &mut self.raw_data.data).await?;
         }
@@ -41,79 +43,126 @@ impl<R: AsyncRead + Unpin + Send> StreamFrameReader<R> {
         self.raw_data.consumed += 1;
         Ok(b)
     }
+    async fn get_frame_data_byte(&mut self) -> Result<(), ReceiveFrameError> {
+        if self.frame_data.data.is_empty() {
+            let mut lendata: Vec<u8> = vec![];
+            let frame_len = loop {
+                lendata.push(self.get_raw_byte().await?);
+                let mut buffrd = BufReader::new(&lendata[..]);
+                let mut rd = ChainPackReader::new(&mut buffrd);
+                match rd.read_uint_data() {
+                    Ok(len) => { break len as usize }
+                    Err(err) => {
+                        let ReadError{reason, .. } = err;
+                        match reason {
+                            ReadErrorReason::UnexpectedEndOfStream => { continue }
+                            ReadErrorReason::InvalidCharacter => { return Err(ReceiveFrameError::FrameError) }
+                        }
+                    }
+                };
+            };
+            let proto = self.get_raw_byte().await?;
+            if proto == Protocol::ResetSession as u8 {
+                return Err(ReceiveFrameError::StreamError);
+            }
+            if proto != Protocol::ChainPack as u8 {
+                return Err(ReceiveFrameError::FrameError);
+            }
+            self.frame_len = frame_len;
+        }
+        if self.frame_data.data.len() == self.frame_len {
+            self.frame_data.complete = true;
+        }
+        Ok(())
+    }
 }
 #[async_trait]
 impl<R: AsyncRead + Unpin + Send> FrameReader for StreamFrameReader<R> {
-    async fn try_receive_frame(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
-        let make_error = |err: ReceiveFrameError| {
-            self.reset_frame(None);
-            Err(err)
-        };
-        loop {
-            if self.frame_len == 0 {
-                let mut lendata: Vec<u8> = vec![];
-                let frame_len = loop {
-                    lendata.push(self.get_byte().await?);
-                    let mut buffrd = BufReader::new(&lendata[..]);
-                    let mut rd = ChainPackReader::new(&mut buffrd);
-                    match rd.read_uint_data() {
-                        Ok(len) => { break len as usize }
-                        Err(err) => {
-                            let msg = err.to_string();
-                            let ReadError{reason, .. } = err;
-                            match reason {
-                                ReadErrorReason::UnexpectedEndOfStream => {
-
-                                }
-                                ReadErrorReason::InvalidCharacter => {
-
-                                }
-                            }
-                        }
-                    };
-                };
-                let proto = self.get_byte().await?;
-                if proto == Protocol::ResetSession as u8 {
-                    return make_error(ReceiveFrameError::StreamError);
-                }
-                if proto != Protocol::ChainPack as u8 {
-                    return make_error(ReceiveFrameError::FrameError);
-                }
-                self.frame_len = frame_len;
-            } else if self.data.len() < self.frame_len {
-                self.get_byte().await?;
-            }
-            if self.meta.is_none() && (self.raw_data.raw_bytes_available() == 0 || self.data.len() == self.frame_len) {
-                let mut buffrd = BufReader::new(&self.data[1..]);
-                let mut rd = ChainPackReader::new(&mut buffrd);
-                if let Ok(Some(meta)) = rd.try_read_meta() {
-                    let pos = rd.position() + 1;
-                    self.data.drain(..pos);
-                    let resp_id = if meta.is_response() {
-                        meta.request_id()
-                    } else {
-                        None
-                    };
-                    self.meta = Some(meta);
-                    if let Some(rqid) = resp_id {
-                        return Ok(RpcFrameReception::ResponseId(rqid));
-                    }
-                } else {
-                    log!(target: "Serial", Level::Debug, "Meta data read error");
-                    return make_error(ReceiveFrameError::FrameError);
-                }
-            }
-            if self.data.len() == self.frame_len && self.meta.is_some() {
-                let frame = RpcFrame {
-                    protocol: Protocol::ChainPack,
-                    meta: take(&mut self.meta).unwrap(),
-                    data: take(&mut self.data),
-                };
-                log!(target: "RpcMsg", Level::Debug, "R==> {}", &frame);
-                return Ok(RpcFrameReception::Frame(frame))
-            }
-        }
+    async fn get_byte(&mut self) -> Result<(), ReceiveFrameError> {
+        self.get_frame_data_byte().await
     }
+
+    fn can_read_meta(&self) -> bool {
+        self.raw_data.raw_bytes_available() == 0 || self.frame_data.data.len() == self.frame_len
+    }
+
+    fn frame_data_ref_mut(&mut self) -> &mut FrameData {
+        &mut self.frame_data
+    }
+
+    fn reset_frame_data(&mut self) {
+        self.reset_frame()
+    }
+    // async fn try_receive_frame(&mut self) -> Result<RpcFrameReception, ReceiveFrameError> {
+    //     let make_error = |err: ReceiveFrameError| {
+    //         self.reset_frame(None);
+    //         Err(err)
+    //     };
+    //     loop {
+    //         if self.frame_len == 0 {
+    //             let mut lendata: Vec<u8> = vec![];
+    //             let frame_len = loop {
+    //                 lendata.push(self.get_byte().await?);
+    //                 let mut buffrd = BufReader::new(&lendata[..]);
+    //                 let mut rd = ChainPackReader::new(&mut buffrd);
+    //                 match rd.read_uint_data() {
+    //                     Ok(len) => { break len as usize }
+    //                     Err(err) => {
+    //                         let msg = err.to_string();
+    //                         let ReadError{reason, .. } = err;
+    //                         match reason {
+    //                             ReadErrorReason::UnexpectedEndOfStream => {
+    //
+    //                             }
+    //                             ReadErrorReason::InvalidCharacter => {
+    //
+    //                             }
+    //                         }
+    //                     }
+    //                 };
+    //             };
+    //             let proto = self.get_byte().await?;
+    //             if proto == Protocol::ResetSession as u8 {
+    //                 return make_error(ReceiveFrameError::StreamError);
+    //             }
+    //             if proto != Protocol::ChainPack as u8 {
+    //                 return make_error(ReceiveFrameError::FrameError);
+    //             }
+    //             self.frame_len = frame_len;
+    //         } else if self.data.len() < self.frame_len {
+    //             self.get_byte().await?;
+    //         }
+    //         if self.meta.is_none() && (self.raw_data.raw_bytes_available() == 0 || self.data.len() == self.frame_len) {
+    //             let mut buffrd = BufReader::new(&self.data[1..]);
+    //             let mut rd = ChainPackReader::new(&mut buffrd);
+    //             if let Ok(Some(meta)) = rd.try_read_meta() {
+    //                 let pos = rd.position() + 1;
+    //                 self.data.drain(..pos);
+    //                 let resp_id = if meta.is_response() {
+    //                     meta.request_id()
+    //                 } else {
+    //                     None
+    //                 };
+    //                 self.meta = Some(meta);
+    //                 if let Some(rqid) = resp_id {
+    //                     return Ok(RpcFrameReception::ResponseId(rqid));
+    //                 }
+    //             } else {
+    //                 log!(target: "Serial", Level::Debug, "Meta data read error");
+    //                 return make_error(ReceiveFrameError::FrameError);
+    //             }
+    //         }
+    //         if self.data.len() == self.frame_len && self.meta.is_some() {
+    //             let frame = RpcFrame {
+    //                 protocol: Protocol::ChainPack,
+    //                 meta: take(&mut self.meta).unwrap(),
+    //                 data: take(&mut self.data),
+    //             };
+    //             log!(target: "RpcMsg", Level::Debug, "R==> {}", &frame);
+    //             return Ok(RpcFrameReception::Frame(frame))
+    //         }
+    //     }
+    // }
 }
 
 pub fn read_frame(buff: &[u8]) -> crate::Result<RpcFrame> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -186,14 +186,18 @@ pub fn split_glob_on_match<'a>(glob_pattern: &'a str, shv_path: &str) -> Result<
     }
 }
 pub fn hex_array(data: &[u8]) -> String {
-    let mut ret = "[".to_string();
+    format!("[0x{}]", hex_string(data, Some(",0x")))
+}
+pub fn hex_string(data: &[u8], delim: Option<&str>) -> String {
+    let mut ret = "".to_string();
     for b in data {
-        if ret.len() > 1 {
-            ret += ",";
+        if let Some(delim) = delim {
+            if ret.len() > 1 {
+                ret += delim;
+            }
         }
-        ret += &format!("0x{:02x}", b);
+        ret += &format!("{:02x}", b);
     }
-    ret += "]";
     ret
 }
 pub fn hex_dump(data: &[u8]) -> String {

--- a/src/util.rs
+++ b/src/util.rs
@@ -236,7 +236,13 @@ pub fn hex_dump(data: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use log::{debug};
     use crate::util::{glob_len, left_glob, split_glob_on_match, starts_with_path, strip_prefix_path};
+    fn init_log() {
+        let _ = env_logger::builder()
+            // .filter(None, LevelFilter::Debug)
+            .is_test(true).try_init();
+    }
 
     #[test]
     fn test_glob_len() {
@@ -308,6 +314,7 @@ mod tests {
     }
     #[test]
     fn test_strip_path() {
+        init_log();
         let data = vec![
             ("", "", Some("")),
             ("", "/", Some("")),
@@ -324,7 +331,7 @@ mod tests {
             ("a/b", "a/bc", None),
         ];
         for (prefix, path, res) in data {
-            println!("prefix: {prefix}, path: {path}");
+            debug!("prefix: {prefix}, path: {path}");
             assert_eq!(strip_prefix_path(path, prefix), res);
         }
     }


### PR DESCRIPTION
Big rewrite of FrameReader

1. Trait method to read frame, dedup SerialFrameReader and StreamFrameReader code
2. 5 sec timeout on data read
3. try_to_read_met call optimized to be done only when whole chunk of data received is traversed