### PR TITLE
Change split character of module-verbosity parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.0.12"
+version = "3.0.13"
 edition = "2021"
 
 [dependencies]

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,7 +71,7 @@ pub fn strip_prefix_path<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
 pub fn parse_log_verbosity<'a>(verbosity: &'a str, module_path: &'a str) -> Vec<(&'a str, LevelFilter)> {
     let mut ret: Vec<(&str, LevelFilter)> = Vec::new();
     for module_level_str in verbosity.split(',') {
-        let module_level: Vec<_> = module_level_str.split(':').collect();
+        let module_level: Vec<_> = module_level_str.split('=').collect();
         // Using `get(0)` looks more consistent along with the following `get(1)`
         #[allow(clippy::get_first)]
         let name = *module_level.get(0).unwrap_or(&".");


### PR DESCRIPTION
Fully qualified module names can contain "::", so another character has to be used to split module name and verbosity.