### PR TITLE
Less data in RpcFrameReception::Meta

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.0.14"
+version = "3.1.0"
 edition = "2021"
 
 [dependencies]

--- a/src/framerw.rs
+++ b/src/framerw.rs
@@ -12,16 +12,13 @@ use crate::util::hex_dump;
 
 #[derive(Debug)]
 pub enum RpcFrameReception {
-    Meta { request_id: Option<RqId>, shv_path: Option<String>, method: Option<String>, source: Option<String> },
+    MetaAnnouncement { response_id: Option<RqId> },
     Frame(RpcFrame),
 }
 impl RpcFrameReception {
     fn from_meta(meta: &MetaMap) -> Self {
-        Self::Meta {
-            request_id: meta.request_id(),
-            shv_path: meta.shv_path().map(|s| s.to_string()),
-            method: meta.method().map(|s| s.to_string()),
-            source: meta.source().map(|s| s.to_string()),
+        Self::MetaAnnouncement {
+            response_id: if meta.is_response() { Some(meta.request_id().unwrap_or_default()) } else { None },
         }
     }
 }

--- a/src/serialrw.rs
+++ b/src/serialrw.rs
@@ -295,7 +295,7 @@ impl<W: AsyncWrite + Unpin + Send> FrameWriter for SerialFrameWriter<W> {
 mod test {
     use super::*;
     use crate::util::{hex_dump, hex_string};
-    use crate::{RpcMessage, RpcMessageMetaTags};
+    use crate::{RpcMessage};
     use async_std::io::BufWriter;
     use crate::framerw::test::from_hex;
 
@@ -338,7 +338,6 @@ mod test {
 
         for with_crc in [false, true] {
             let msg = RpcMessage::new_request("foo/bar", "baz", Some(with_crc.into()));
-            let rqid = msg.request_id();
             let frame = msg.to_frame().unwrap();
             let mut buff: Vec<u8> = vec![];
             let buffwr = BufWriter::new(&mut buff);
@@ -377,10 +376,9 @@ mod test {
                 let Err(ReceiveFrameError::FrameError(_)) = rd.receive_frame_or_meta().await else {
                     panic!("Frame error should be received");
                 };
-                let Ok(RpcFrameReception::Meta { request_id, .. }) = rd.receive_frame_or_meta().await else {
+                let Ok(RpcFrameReception::MetaAnnouncement { .. }) = rd.receive_frame_or_meta().await else {
                     panic!("Meta should be received");
                 };
-                assert_eq!(request_id, rqid);
                 let Ok(RpcFrameReception::Frame(rd_frame)) = rd.receive_frame_or_meta().await else {
                     panic!("Frame should be received");
                 };

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -185,7 +185,7 @@ mod test {
 use crate::framerw::test::from_hex;
     use super::*;
     use crate::util::{hex_array, hex_dump};
-    use crate::{RpcMessage, RpcMessageMetaTags};
+    use crate::{RpcMessage};
     use async_std::io::BufWriter;
     fn init_log() {
         let _ = env_logger::builder()
@@ -208,7 +208,6 @@ use crate::framerw::test::from_hex;
             RpcMessage::new_request("foo/bar", "baz", Some("hello".into())),
             RpcMessage::new_request("foo/bar", "baz", Some((&[0_u8; 128][..]).into())),
         ] {
-            let rqid = msg.request_id();
             let frame = msg.to_frame().unwrap();
 
             let buff = frame_to_data(&frame).await;
@@ -224,10 +223,9 @@ use crate::framerw::test::from_hex;
             {
                 let buffrd = async_std::io::BufReader::new(&*buff);
                 let mut rd = StreamFrameReader::new(buffrd);
-                let Ok(RpcFrameReception::Meta{ request_id, .. }) = rd.receive_frame_or_meta().await else {
+                let Ok(RpcFrameReception::MetaAnnouncement { .. }) = rd.receive_frame_or_meta().await else {
                     panic!("Meta should be received");
                 };
-                assert_eq!(request_id, rqid);
                 let Ok(RpcFrameReception::Frame(rd_frame)) = rd.receive_frame_or_meta().await else {
                     panic!("Frame should be received");
                 };


### PR DESCRIPTION
It doesn't make sense to copy almost all the meta if the information only needed id response ID