### PR TITLE
Simplify constructs in rpcmessage and metamethod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.0.20"
+version = "3.0.21"
 edition = "2021"
 
 [dependencies]

--- a/src/metamethod.rs
+++ b/src/metamethod.rs
@@ -74,10 +74,7 @@ impl AccessLevel {
 }
 impl From<&str> for AccessLevel {
     fn from(value: &str) -> Self {
-        match Self::from_str(value) {
-            None => { Self::Browse }
-            Some(acc) => { acc }
-        }
+        Self::from_str(value).unwrap_or(Self::Browse)
     }
 }
 
@@ -210,7 +207,7 @@ impl From<DirAttribute> for &str {
 }
 impl From<DirAttribute> for String {
     fn from(val: DirAttribute) -> Self {
-        <DirAttribute as Into<&str>>::into(val).to_string()
+        <&str>::from(val).to_string()
     }
 }
 


### PR DESCRIPTION
Refactor some constructs that haven't been found by clippy, such as manual implementation of Option or Result methods, unnecessary return statement and redundant use of `self` in expressions returning `self` itself.