### PR TITLE
Replace `RpcValue::value()` getter with direct `value` field access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "shvrpc"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 
 [dependencies]
-shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs.git", branch = "master", version = "3.1.0" }
+shvproto = { git = "https://github.com/silicon-heaven/libshvproto-rs.git", branch = "master", version = "3.2.0" }
 futures = "0.3.29"
 log = "0.4.21"
 sha1 = "0.10.6"

--- a/src/metamethod.rs
+++ b/src/metamethod.rs
@@ -101,7 +101,7 @@ impl TryFrom<&RpcValue> for AccessLevel {
     type Error = String;
     fn try_from(value: &RpcValue) -> Result<Self, Self::Error> {
         use shvproto::rpcvalue::Value;
-        match value.value() {
+        match &value.value {
             Value::Int(val) => (*val as i32).try_into(),
             Value::String(val) =>
                 AccessLevel::from_str(val.as_str())

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -265,11 +265,17 @@ mod tests {
             ("test/device/track:ls:lsmod", "test/**:get:*chng", false),
             ("test/device/track:ls:lsmod", "test/*:ls:lsmod", true),
             ("test/device/track:ls:lsmod", "test/**:get", false),
+
+            ("test/device/track:*:chng", "test/device/*:*:chng", true),
+            ("test/device/track:*:chng", "test/device/track:*:chng", true),
+            ("test/device/track:*:chng", "test/device/track:*:chng", true),
+
+            ("value:*:chng", "value:*:*", true),
         ] {
             // println!("{path} {ri}");
             let glob = ShvRI::try_from(ri)?.to_glob()?;
             let m = glob.match_shv_ri(&ShvRI::try_from(path)?);
-            assert_eq!(m, is_match);
+            assert_eq!(m, is_match, "glob: {}, ri: {path}, matches: {m}, expect: {is_match}", glob.as_str());
         }
         Ok(())
     }

--- a/src/rpcdiscovery.rs
+++ b/src/rpcdiscovery.rs
@@ -12,7 +12,7 @@ pub enum LsParam {
 
 impl From<&RpcValue> for LsParam {
     fn from(value: &RpcValue) -> Self {
-        match value.value() {
+        match &value.value {
             shvproto::Value::String(dirname) => LsParam::Exists(String::clone(dirname)),
             _ => LsParam::List,
         }
@@ -65,7 +65,7 @@ impl TryFrom<LsResult> for Vec<String> {
 impl TryFrom<&RpcValue> for LsResult {
     type Error = String;
     fn try_from(rpcvalue: &RpcValue) -> Result<Self, Self::Error> {
-        match rpcvalue.value() {
+        match &rpcvalue.value {
             shvproto::Value::Bool(false) | shvproto::Value::Null => Ok(LsResult::Exists(false)),
             shvproto::Value::Bool(true) => Ok(LsResult::Exists(true)),
             shvproto::Value::List(_) => Ok(LsResult::List(rpcvalue.try_into()?)),
@@ -90,7 +90,7 @@ pub enum DirParam {
 
 impl From<&RpcValue> for DirParam {
     fn from(rpcvalue: &RpcValue) -> Self {
-        match rpcvalue.value() {
+        match &rpcvalue.value {
             shvproto::Value::String(param) => DirParam::Exists(param.to_string()),
             shvproto::Value::Bool(true) => DirParam::Full,
             _ => DirParam::Brief,
@@ -129,7 +129,7 @@ pub struct MethodInfo {
 impl TryFrom<&RpcValue> for MethodInfo {
     type Error = String;
     fn try_from(value: &RpcValue) -> Result<Self, Self::Error> {
-        match value.value() {
+        match &value.value {
             shvproto::Value::Map(map) => {
                 let get_key = |key: DirAttribute| {
                     map.get(key.into()).ok_or_else(|| format!("Missing MethodInfo key `{}` in Map", <&str>::from(key)))
@@ -164,7 +164,7 @@ impl TryFrom<&RpcValue> for MethodInfo {
                         for (key, val) in signals_map.into_iter() {
                             res.insert(
                                 key.to_owned(),
-                                match val.value() {
+                                match &val.value {
                                     shvproto::Value::Null => Ok(None),
                                     shvproto::Value::String(val) => Ok(Some(val.to_string())),
                                     _ => Err(format_err(DirAttribute::Signals, &format!("Wrong item at key `{key}`: {}", val.type_name()))),
@@ -211,7 +211,7 @@ impl TryFrom<&RpcValue> for MethodInfo {
                         for (key, val) in signals_map.into_iter() {
                             res.insert(
                                 key.to_owned(),
-                                match val.value() {
+                                match &val.value {
                                     shvproto::Value::Null => Ok(None),
                                     shvproto::Value::String(val) => Ok(Some(val.to_string())),
                                     _ => Err(format_err(DirAttribute::Signals, &format!("Wrong item at key `{key}`: {}", val.type_name()))),
@@ -258,7 +258,7 @@ impl TryFrom<DirResult> for Vec<MethodInfo> {
 impl TryFrom<&RpcValue> for DirResult {
     type Error = String;
     fn try_from(rpcvalue: &RpcValue) -> Result<Self, Self::Error> {
-        match rpcvalue.value() {
+        match &rpcvalue.value {
             shvproto::Value::Bool(false) | shvproto::Value::Null => Ok(DirResult::Exists(false)),
             shvproto::Value::Bool(true) => Ok(DirResult::Exists(true)),
             shvproto::Value::Map(_) | shvproto::Value::IMap(_) =>

--- a/src/rpcframe.rs
+++ b/src/rpcframe.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::io::{BufReader};
+use std::io::BufReader;
 use shvproto::{ChainPackReader, ChainPackWriter, MetaMap, RpcValue};
 use shvproto::writer::Writer;
 use shvproto::reader::Reader;
@@ -33,9 +33,9 @@ impl RpcFrame {
         let mut data = Vec::new();
         {
             let mut wr = ChainPackWriter::new(&mut data);
-            wr.write_value(msg.as_rpcvalue().value())?;
+            wr.write_value(&msg.as_rpcvalue().value)?;
         }
-        let meta = msg.as_rpcvalue().meta().clone();
+        let meta = *msg.as_rpcvalue().meta.clone().unwrap_or_default();
         Ok(RpcFrame { protocol: Protocol::ChainPack, meta, data })
     }
     pub fn to_rpcmesage(&self) -> crate::Result<RpcMessage> {


### PR DESCRIPTION
The getter was removed in libshvproto 3.2.0.