### PR TITLE
streamrw: Log RpcFrame correctly in send_frame()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.2.1"
+version = "3.2.2"
 edition = "2021"
 
 [dependencies]

--- a/src/streamrw.rs
+++ b/src/streamrw.rs
@@ -177,7 +177,7 @@ impl<W: AsyncWrite + Unpin + Send> FrameWriter for StreamFrameWriter<W> {
         self.peer_id = peer_id
     }
     async fn send_frame(&mut self, frame: RpcFrame) -> crate::Result<()> {
-        log!(target: "RpcMsg", Level::Debug, "S<== {} {}", format_peer_id(self.peer_id), &frame.to_rpcmesage().unwrap_or_default());
+        log!(target: "RpcMsg", Level::Debug, "S<== {} {}", format_peer_id(self.peer_id), &frame.to_rpcmesage().map_or_else(|_| frame.to_string(), |rpc_msg| rpc_msg.to_string()));
         let meta_data = serialize_meta(&frame)?;
         let mut header = Vec::new();
         let mut wr = ChainPackWriter::new(&mut header);


### PR DESCRIPTION
Log a RpcFrame to send as a RpcMessage only if the frame is convertible to a valid RpcMessage.