### PR TITLE
Ignore non-binary WebSocket messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Fixes a bug when the FrameReader accepted any message, which resulted in

`framerw.rs:84:17: assertion failed: !__self.frame_data_ref().data.is_empty()`