### PR TITLE
util: Extend join_path for multiple path segments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.5.0"
+version = "3.6.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
This commit introduces a new macro `join_path!` to simplify the joining of multiple path segments.

The `join_path` utility function now accepts `impl AsRef<str>` for its arguments, making it more flexible.