### PR TITLE
canrw: Refactor frame handling and add accessors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.8.5"
+version = "3.8.6"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Remove Remote variant from ShvCanFrame as unused

Add accessor methods for DataFrameHeader, DataFrame, AckFrame, TerminateFrame, and RemoteFrame

Change TryFrom implementations to take references (&DataFrame, &AckFrame, &TerminateFrame)

Refactor CanFrameReader and CanFrameWriter to work directly with DataFrame instead of ShvCanFrame

Simplify tests by removing redundant ShvCanFrame::Data wrapping

Bump crate version to 3.8.6