### PR TITLE
canrw: Fix frame_counter incrementation in CanFrameWriter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shvrpc"
-version = "3.8.10"
+version = "3.8.11"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Use overflowing_add instead of saturating_add and +=.